### PR TITLE
:lipstick: Visited links doesn't change color anymore

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,3 +11,7 @@ header a:hover {
     color: #fff;
     text-decoration: underline;
 }
+
+header a:visited {
+    color: #fff;
+}


### PR DESCRIPTION
I think links shouldn't change color when visited, because:

1. Aesthetic Consistency: A uniform color for links can maintain aesthetic consistency throughout the website. Potential risk is affecting the user’s visual experience negatively.

2. Minimalist Design Philosophy: Chimeras design philosophy contains the word *clean*, which (imo) when changing the color of visited links might disrupt this simplicity and clutter the visual field, contradicting the core design principles of the site.